### PR TITLE
add missing quoteVolume

### DIFF
--- a/src/rest/RESTClient.ts
+++ b/src/rest/RESTClient.ts
@@ -242,7 +242,8 @@ export class RESTClient {
           highPrice: value[2].toString(),
           lowPrice: value[3].toString(),
           closePrice: value[4].toString(),
-          volume: value[5].toString()
+          volume: value[5].toString(),
+          quoteVolume: value[6].toString()
         }));
       }
       return result as MarketOHLC;


### PR DESCRIPTION
To my understanding, https://github.com/cryptowatch/cw-sdk-node/pull/12 introduced a build error which this PR tries to solve.

I believe I fixed in the correct way. Without this, you get an error about a missing `quoteVolume`.

```
yarn build
yarn run v1.22.5
$ tsc -p tsconfig.release.json
src/rest/RESTClient.ts:239:86 - error TS2741: Property 'quoteVolume' is missing in type '{ closeTime: number; openPrice: string; highPrice: string; lowPrice: string; closePrice: string; volume: string; }' but required in type 'CandleData'.

239         result[key as Period] = marketOHLC[key as Period].map<CandleData>((value) => ({
                                                                                         ~~
240           closeTime: value[0],
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
... 
245           volume: value[5].toString()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
246         }));
    ~~~~~~~~~~

  src/rest/types/data.ts:145:3
    145   quoteVolume: string;
          ~~~~~~~~~~~
    'quoteVolume' is declared here.
  node_modules/typescript/lib/lib.es5.d.ts:1331:24
    1331     map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[];
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    The expected type comes from the return type of this signature.


Found 1 error.
```