### PR TITLE
instruct compiler to generate declarations

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "alwaysStrict": true,
     "strict": true,
     "sourceMap": true,
+    "declaration": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
This fixes #19 

It instructs the compiler to generate type definition files. The `package.json` file is already correctly pointing to the file, but it wasn't being generated.

Keep in mind that without the fix #25, the build will probably fail.