### PR TITLE
fix relative imports

### DIFF
--- a/src/orderbook/__mocks__/OrderBookWatcher.ts
+++ b/src/orderbook/__mocks__/OrderBookWatcher.ts
@@ -1,4 +1,4 @@
-import { Updater } from 'orderbook/Updater';
+import { Updater } from './Updater';
 import { StreamClient } from 'websocket';
 import { cachedMocks } from './mockCache';
 

--- a/src/orderbook/__mocks__/SnapshotRetriever.ts
+++ b/src/orderbook/__mocks__/SnapshotRetriever.ts
@@ -1,6 +1,6 @@
 import { mockSnapshot } from '../__tests__/data/snapshot';
-import { RESTClient } from 'rest';
-import { MarketSymbol } from 'util/types/shared';
+import { RESTClient } from '../../rest';
+import { MarketSymbol } from '../../util/types/shared';
 import { cachedMocks } from './mockCache';
 
 export class SnapshotRetriever {

--- a/src/orderbook/__mocks__/Updater.ts
+++ b/src/orderbook/__mocks__/Updater.ts
@@ -1,6 +1,6 @@
-import { SnapshotRetriever } from 'orderbook/SnapshotRetriever';
+import { SnapshotRetriever } from '../SnapshotRetriever';
 import { cachedMocks } from './mockCache';
-import { OrderBookDelta } from 'util/types/shared';
+import { OrderBookDelta } from '../../util/types/shared';
 
 export class Updater {
   snapshotRetriever: SnapshotRetriever;

--- a/src/orderbook/__tests__/OrderBookWatcher.test.ts
+++ b/src/orderbook/__tests__/OrderBookWatcher.test.ts
@@ -2,7 +2,7 @@ import { OrderBookWatcher } from '../OrderBookWatcher';
 import { Substitute, Arg, SubstituteOf } from '@fluffy-spoon/substitute';
 import { Updater } from '../Updater';
 import { StreamClient } from '../../websocket/StreamClient';
-import { OrderBookSnapshot, OrderBookState } from 'util/types/shared';
+import { OrderBookSnapshot, OrderBookState } from '../../util/types/shared';
 
 describe('OrderBookWatcher.js tests', () => {
   describe('constructor tests', () => {

--- a/src/orderbook/__tests__/data/deltas.ts
+++ b/src/orderbook/__tests__/data/deltas.ts
@@ -1,4 +1,4 @@
-import { OrderBookDelta } from 'util/types/shared';
+import { OrderBookDelta } from '../../../util/types/shared';
 
 export const mockDelta1: OrderBookDelta = {
   seqNum: 1012075,

--- a/src/orderbook/__tests__/index.test.ts
+++ b/src/orderbook/__tests__/index.test.ts
@@ -1,13 +1,13 @@
-import { createOrderBookWatcher } from 'orderbook';
+import { createOrderBookWatcher } from '../index';
 import Substitute, { Arg } from '@fluffy-spoon/substitute';
-import { StreamClient } from 'websocket';
-import { RESTClient } from 'rest';
-import { getLastInitializedSnapshotRetriever } from 'orderbook/__mocks__/SnapshotRetriever';
-import { resetCache } from 'orderbook/__mocks__/mockCache';
-import { getLastInitializedUpdater } from 'orderbook/__mocks__/Updater';
-import { Market } from 'util/types/shared';
-import { getLastInitializedWatcher } from 'orderbook/__mocks__/OrderBookWatcher';
-import { MarketUpdate } from 'websocket/types/markets';
+import { StreamClient } from '../../websocket';
+import { RESTClient } from '../../rest';
+import { getLastInitializedSnapshotRetriever } from '../__mocks__/SnapshotRetriever';
+import { resetCache } from '../__mocks__/mockCache';
+import { getLastInitializedUpdater } from '../__mocks__/Updater';
+import { Market } from '../../util/types/shared';
+import { getLastInitializedWatcher } from '../__mocks__/OrderBookWatcher';
+import { MarketUpdate } from '../../websocket/types/markets';
 import { mocked } from 'ts-jest/utils';
 
 jest.mock('orderbook/Updater');

--- a/src/rest/__tests__/RESTClient.test.ts
+++ b/src/rest/__tests__/RESTClient.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { RESTClient } from 'rest/RESTClient';
+import { RESTClient } from '../RESTClient';
 import superagent from 'superagent';
 import superagentMocker from 'superagent-mocker';
-import { loadRESTCredentials } from 'util/credentials';
+import { loadRESTCredentials } from '../../util/credentials';
 import {
   EXCHANGES,
   EXCHANGE_KRAKEN,

--- a/src/util/credentials.ts
+++ b/src/util/credentials.ts
@@ -3,7 +3,7 @@ import yaml from 'js-yaml';
 import os from 'os';
 import path from 'path';
 import logger from '../util/logger';
-import { RESTOpts } from 'rest/types/client';
+import { RESTOpts } from '../rest/types/client';
 import { Credentials, CredentialsType } from './types/credentials';
 import { StreamOpts, TradeOpts } from '../websocket/types/client';
 

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -1,7 +1,7 @@
 import { isLong } from 'long';
 import { DeltaItem, PublicOrder, OrderBookSnapshot } from './types/shared';
 import { Decimal } from 'decimal.js-light';
-import { OrderBookSnapshotRaw } from 'rest/types/data';
+import { OrderBookSnapshotRaw } from '../rest/types/data';
 
 export function guardIsLong(value: number | Long): value is Long {
   return isLong(value);


### PR DESCRIPTION
I was getting this error while trying to use the library. I figured I should change everything to relative imports since it's safer anyway.

```
node_modules/cw-sdk-node/build/websocket/types/markets.d.ts:1:64 - error TS2307: Cannot find module 'util/types/shared' or its corresponding type declarations.

1 import { PublicOrder, OrderBookSnapshot, OrderBookDelta } from 'util/types/shared';
                                                                 ~~~~~~~~~~~~~~~~~~~
```